### PR TITLE
Fix: ix64/unlock-music镜像下架导致docker-compose无法工作

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -31,6 +31,6 @@ services:
           memory: 500m
 
   unlock-music: # 解锁音乐的应用
-    image: ix64/unlock-music:v1.10.0
+    image: jiabh/unlock-music:v1.10.0
     environment:
       TZ: Asia/Shanghai


### PR DESCRIPTION
Fix #1

将 `unlock-music:v1.10.0` 构建并推送至我自己的Docker Hub：[zhaosuizhi/unlock-music](https://hub.docker.com/r/zhaosuizhi/unlock-music/tags)